### PR TITLE
Require a listener registration before sending

### DIFF
--- a/firmware/tellsticknet.c
+++ b/firmware/tellsticknet.c
@@ -21,11 +21,14 @@
 static UDP_PORT localPort;
 static UDP_SOCKET s = INVALID_UDP_SOCKET;
 static NODE_INFO	remote;
+static int listenerActive = 0;
 
 void registerListener() {
 	memcpy(&remote, &UDPSocketInfo[localSocket].remote, sizeof(remote));
 	localPort = UDPSocketInfo[localSocket].remotePort;
 
+	listenerActive = 1;
+	
 	if(s != INVALID_UDP_SOCKET) {
 		UDPClose(s);
 		s = INVALID_UDP_SOCKET;
@@ -37,6 +40,9 @@ void sendToLocalListeners() {
 	int i, len;
 	char *b;
 
+	/* Only transmit if at least one listener has registered */
+	if (!listenerActive) return;
+	
 	if(s == INVALID_UDP_SOCKET) {
 		s = UDPOpen(localPort, &remote, localPort);
 	}


### PR DESCRIPTION
If sendToLocalListeners() is invoked before a listener has registered, the function will emit a packet to 0.0.0.0 port 0, since the variables remote and localPort have not yet been initialized.

In some reported circumstances this causes problems with the DHCP server of certain cable-internet routers which sees the emitted packet having the device MAC address and the default address 192.168.0.51 (at https://github.com/telldus/tellstick-net/blob/master/firmware/TCPIPConfig.h#L28 ). The DHCP server then assumes that the device is already assigned an adress and does not hand it a DHCP address, which leads to a non-connected/red-light device.

The proposed patch adds a flag, "listenerActive", which is set to true when at least one listener has registered. If no listener has registered, no UDP packet with a set source address will be put out, and thus the device should be granted the DHCP lease as usual.